### PR TITLE
Do not log to stdout.

### DIFF
--- a/config/environment.rb
+++ b/config/environment.rb
@@ -1,7 +1,5 @@
 # Load the rails application
 require File.expand_path('../application', __FILE__)
 
-Rails.logger = Logger.new(STDOUT)
-
 # Initialize the rails application
 Crm::Application.initialize!


### PR DESCRIPTION
The test suite (WIP) is really hard to read when it's clutterred with a log of
details.  log/test.log is still available in case of necessity.